### PR TITLE
Fix typo in parsing rules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,5 +23,5 @@ URL: https://github.com/Tazinho/snakecase
 BugReports: https://github.com/Tazinho/snakecase/issues
 Encoding: UTF-8
 License: GPL-3
-RoxygenNote: 6.1.1
+RoxygenNote: 7.3.2
 VignetteBuilder: knitr

--- a/R/to_any_case.R
+++ b/R/to_any_case.R
@@ -55,7 +55,7 @@
 #' \itemize{
 #'  \item{1: \code{"RRRStudio" -> "RRR_Studio"}}
 #'  \item{2: \code{"RRRStudio" -> "RRRS_tudio"}}
-#'  \item{3: \code{"RRRStudio" -> "RRRSStudio"}. This will become for example \code{"Rrrstudio"} when we convert to lower camel case.}
+#'  \item{3: \code{"RRRStudio" -> "RRRStudio"}. This will become for example \code{"Rrrstudio"} when we convert to lower camel case.}
 #'  \item{-1, -2, -3: These \code{parsing_options}'s will suppress the conversion after non-alphanumeric values.}
 #'  \item{0: no parsing}
 #'  }

--- a/man/caseconverter.Rd
+++ b/man/caseconverter.Rd
@@ -16,65 +16,173 @@
 \alias{to_title_case}
 \title{Specific case converter shortcuts}
 \usage{
-to_snake_case(string, abbreviations = NULL, sep_in = "[^[:alnum:]]",
-  parsing_option = 1, transliterations = NULL, numerals = "middle",
-  sep_out = NULL, unique_sep = NULL, empty_fill = NULL,
-  prefix = "", postfix = "")
+to_snake_case(
+  string,
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = "middle",
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 
-to_lower_camel_case(string, abbreviations = NULL,
-  sep_in = "[^[:alnum:]]", parsing_option = 1,
-  transliterations = NULL, numerals = "middle", sep_out = NULL,
-  unique_sep = NULL, empty_fill = NULL, prefix = "", postfix = "")
+to_lower_camel_case(
+  string,
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = "middle",
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 
-to_upper_camel_case(string, abbreviations = NULL,
-  sep_in = "[^[:alnum:]]", parsing_option = 1,
-  transliterations = NULL, numerals = "middle", sep_out = NULL,
-  unique_sep = NULL, empty_fill = NULL, prefix = "", postfix = "")
+to_upper_camel_case(
+  string,
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = "middle",
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 
-to_screaming_snake_case(string, abbreviations = NULL,
-  sep_in = "[^[:alnum:]]", parsing_option = 1,
-  transliterations = NULL, numerals = "middle", sep_out = NULL,
-  unique_sep = NULL, empty_fill = NULL, prefix = "", postfix = "")
+to_screaming_snake_case(
+  string,
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = "middle",
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 
-to_parsed_case(string, abbreviations = NULL, sep_in = "[^[:alnum:]]",
-  parsing_option = 1, transliterations = NULL, numerals = "middle",
-  sep_out = NULL, unique_sep = NULL, empty_fill = NULL,
-  prefix = "", postfix = "")
+to_parsed_case(
+  string,
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = "middle",
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 
-to_mixed_case(string, abbreviations = NULL, sep_in = "[^[:alnum:]]",
-  parsing_option = 1, transliterations = NULL, numerals = "middle",
-  sep_out = NULL, unique_sep = NULL, empty_fill = NULL,
-  prefix = "", postfix = "")
+to_mixed_case(
+  string,
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = "middle",
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 
-to_lower_upper_case(string, abbreviations = NULL,
-  sep_in = "[^[:alnum:]]", parsing_option = 1,
-  transliterations = NULL, numerals = "middle", sep_out = NULL,
-  unique_sep = NULL, empty_fill = NULL, prefix = "", postfix = "")
+to_lower_upper_case(
+  string,
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = "middle",
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 
-to_upper_lower_case(string, abbreviations = NULL,
-  sep_in = "[^[:alnum:]]", parsing_option = 1,
-  transliterations = NULL, numerals = "middle", sep_out = NULL,
-  unique_sep = NULL, empty_fill = NULL, prefix = "", postfix = "")
+to_upper_lower_case(
+  string,
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = "middle",
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 
-to_swap_case(string, abbreviations = NULL, sep_in = "[^[:alnum:]]",
-  parsing_option = 1, transliterations = NULL, numerals = "middle",
-  sep_out = NULL, unique_sep = NULL, empty_fill = NULL,
-  prefix = "", postfix = "")
+to_swap_case(
+  string,
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = "middle",
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 
-to_sentence_case(string, abbreviations = NULL, sep_in = "[^[:alnum:]]",
-  parsing_option = 1, transliterations = NULL, numerals = "middle",
-  sep_out = NULL, unique_sep = NULL, empty_fill = NULL,
-  prefix = "", postfix = "")
+to_sentence_case(
+  string,
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = "middle",
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 
-to_random_case(string, abbreviations = NULL, sep_in = "[^[:alnum:]]",
-  parsing_option = 1, transliterations = NULL, numerals = "middle",
-  sep_out = NULL, unique_sep = NULL, empty_fill = NULL,
-  prefix = "", postfix = "")
+to_random_case(
+  string,
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = "middle",
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 
-to_title_case(string, abbreviations = NULL, sep_in = "[^[:alnum:]]",
-  parsing_option = 1, transliterations = NULL, numerals = "middle",
-  sep_out = NULL, unique_sep = NULL, empty_fill = NULL,
-  prefix = "", postfix = "")
+to_title_case(
+  string,
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = "middle",
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 }
 \arguments{
 \item{string}{A string (for example names of a data frame).}
@@ -161,8 +269,6 @@ to_title_case(strings)
 \href{https://github.com/Tazinho/snakecase}{snakecase on github}, \code{\link{to_any_case}} for flexible high level conversion and more examples.
 }
 \author{
-Malte Grosser, \email{malte.grosser@gmail.com}
-
 Malte Grosser, \email{malte.grosser@gmail.com}
 }
 \keyword{utilities}

--- a/man/check_design_rule.Rd
+++ b/man/check_design_rule.Rd
@@ -4,9 +4,17 @@
 \alias{check_design_rule}
 \title{Internal helper to test the design rules for any string and setting of \code{to_any_case()}}
 \usage{
-check_design_rule(string, sep_in = NULL, transliterations = NULL,
-  sep_out = NULL, prefix = "", postfix = "", unique_sep = NULL,
-  empty_fill = NULL, parsing_option = 1)
+check_design_rule(
+  string,
+  sep_in = NULL,
+  transliterations = NULL,
+  sep_out = NULL,
+  prefix = "",
+  postfix = "",
+  unique_sep = NULL,
+  empty_fill = NULL,
+  parsing_option = 1
+)
 }
 \arguments{
 \item{string}{A string (for example names of a data frame).}

--- a/man/to_any_case.Rd
+++ b/man/to_any_case.Rd
@@ -4,14 +4,22 @@
 \alias{to_any_case}
 \title{General case conversion}
 \usage{
-to_any_case(string, case = c("snake", "small_camel", "big_camel",
-  "screaming_snake", "parsed", "mixed", "lower_upper", "upper_lower",
-  "swap", "all_caps", "lower_camel", "upper_camel", "internal_parsing",
-  "none", "flip", "sentence", "random", "title"), abbreviations = NULL,
-  sep_in = "[^[:alnum:]]", parsing_option = 1,
-  transliterations = NULL, numerals = c("middle", "left", "right",
-  "asis", "tight"), sep_out = NULL, unique_sep = NULL,
-  empty_fill = NULL, prefix = "", postfix = "")
+to_any_case(
+  string,
+  case = c("snake", "small_camel", "big_camel", "screaming_snake", "parsed", "mixed",
+    "lower_upper", "upper_lower", "swap", "all_caps", "lower_camel", "upper_camel",
+    "internal_parsing", "none", "flip", "sentence", "random", "title"),
+  abbreviations = NULL,
+  sep_in = "[^[:alnum:]]",
+  parsing_option = 1,
+  transliterations = NULL,
+  numerals = c("middle", "left", "right", "asis", "tight"),
+  sep_out = NULL,
+  unique_sep = NULL,
+  empty_fill = NULL,
+  prefix = "",
+  postfix = ""
+)
 }
 \arguments{
 \item{string}{A string (for example names of a data frame).}
@@ -67,7 +75,7 @@ the strings into substrings and specify the word boundaries.}
 \itemize{
  \item{1: \code{"RRRStudio" -> "RRR_Studio"}}
  \item{2: \code{"RRRStudio" -> "RRRS_tudio"}}
- \item{3: \code{"RRRStudio" -> "RRRSStudio"}. This will become for example \code{"Rrrstudio"} when we convert to lower camel case.}
+ \item{3: \code{"RRRStudio" -> "RRRStudio"}. This will become for example \code{"Rrrstudio"} when we convert to lower camel case.}
  \item{-1, -2, -3: These \code{parsing_options}'s will suppress the conversion after non-alphanumeric values.}
  \item{0: no parsing}
  }}
@@ -115,7 +123,7 @@ to_upper_camel_case("succesfullGMBH", abbreviations = "GmbH")
 to_title_case("succesfullGMBH", abbreviations = "GmbH")
 
 ### sep_in (input separator)
-string <- "R.St\\u00FCdio: v.1.0.143"
+string <- "R.St\u00FCdio: v.1.0.143"
 to_any_case(string)
 to_any_case(string, sep_in = ":|\\\\.")
 to_any_case(string, sep_in = ":|(?<!\\\\d)\\\\.")
@@ -134,7 +142,7 @@ to_parsed_case("PARSingOption3", parsing_option = 3)
 to_any_case("HAMBURGcity", parsing_option = 0)
 
 ### transliterations
-to_any_case("\\u00E4ngstlicher Has\\u00EA", transliterations = c("german", "Latin-ASCII"))
+to_any_case("\u00E4ngstlicher Has\u00EA", transliterations = c("german", "Latin-ASCII"))
 
 ### case
 strings <- c("this Is a Strange_string", "AND THIS ANOTHER_One")

--- a/man/to_parsed_case_internal.Rd
+++ b/man/to_parsed_case_internal.Rd
@@ -4,8 +4,13 @@
 \alias{to_parsed_case_internal}
 \title{Internal parser, which is relevant for preprocessing, parsing and parsing options}
 \usage{
-to_parsed_case_internal(string, parsing_option = 1L, numerals,
-  abbreviations, sep_in)
+to_parsed_case_internal(
+  string,
+  parsing_option = 1L,
+  numerals,
+  abbreviations,
+  sep_in
+)
 }
 \arguments{
 \item{string}{A string.}


### PR DESCRIPTION
I was trying to figure out how/why parsing_option 3 would insert an extra "S", and finally realized it's a typo in the help.